### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/archive-if-ccc-up.yml
+++ b/.github/workflows/archive-if-ccc-up.yml
@@ -1,5 +1,8 @@
 name: Archive Now if CCC is Up
 
+permissions:
+  contents: write
+
 on:
   schedule:
     - cron: '*/30 * * * *'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,9 @@
 name: Build and Deploy Hugo Site
 
+permissions:
+  contents: read
+  pages: write
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/clockcrockwork/ccc-maintenance/security/code-scanning/2](https://github.com/clockcrockwork/ccc-maintenance/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's tasks:
- `contents: read` is needed to read the repository contents.
- `pages: write` is required for deploying to GitHub Pages.
- No other permissions appear necessary.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
